### PR TITLE
Remove use of boost/filesystem/convenience.hpp so Vina can be built with boost 1.85.0

### DIFF
--- a/AutoDock-Vina-GPU-2.1/main/main.cpp
+++ b/AutoDock-Vina-GPU-2.1/main/main.cpp
@@ -28,7 +28,6 @@
 #include <boost/program_options.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/exception.hpp>
-#include <boost/filesystem/convenience.hpp> // filesystem::basename
 #include <boost/thread/thread.hpp> // hardware_concurrency // FIXME rm ?
 #include "parse_pdbqt.h"
 #include "parallel_mc.h"

--- a/QuickVina-W-GPU-2.1/main/main.cpp
+++ b/QuickVina-W-GPU-2.1/main/main.cpp
@@ -28,7 +28,6 @@
 #include <boost/program_options.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/exception.hpp>
-#include <boost/filesystem/convenience.hpp> // filesystem::basename
 #include <boost/thread/thread.hpp> // hardware_concurrency // FIXME rm ?
 #include "parse_pdbqt.h"
 #include "parallel_mc.h"

--- a/QuickVina2-GPU-2.1/main/main.cpp
+++ b/QuickVina2-GPU-2.1/main/main.cpp
@@ -28,7 +28,6 @@
 #include <boost/program_options.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/exception.hpp>
-#include <boost/filesystem/convenience.hpp> // filesystem::basename
 #include <boost/thread/thread.hpp> // hardware_concurrency // FIXME rm ?
 #include "parse_pdbqt.h"
 #include "parallel_mc.h"


### PR DESCRIPTION
This header was removed in boost 1.85.0. The function it was included for (filesystem::basename) does not appear to be used anymore by the AutoDock Vina code.